### PR TITLE
Fix anchor tag warning

### DIFF
--- a/src/components/ArchitectNextSteps.js
+++ b/src/components/ArchitectNextSteps.js
@@ -18,11 +18,11 @@ class ArchitectNextSteps extends React.Component {
                                 <li>Go to <kbd>react/src/App.js</kbd> in your project folder and open it.</li>
                                 <li>Update the subtitle <kbd>“Favorite Movies”</kbd> to <kbd>“&lt;Your name&gt;’s Favorite Movies”</kbd></li>
                                 <li>The app will automatically apply the new changes!</li>
-                                <li>For additional information, check out our <a target={"_blank"} href="https://docs.architect.io/">docs</a>.</li>
+                                <li>For additional information, check out our <a target={"_blank"} rel="noreferrer" href="https://docs.architect.io/">docs</a>.</li>
                             </ul>
                         <li>Deploy your app to the cloud via Architect</li>
                             <ul>
-                                <li>Create an account at <a target={"_blank"} href="https://cloud.architect.io/signup">architect.io</a></li>
+                                <li>Create an account at <a target={"_blank"} rel="noreferrer" href="https://cloud.architect.io/signup">architect.io</a></li>
                                 <li>Login from the CLI via <kbd>architect login</kbd></li>
                                 <li>Register all your components created from the <kbd>init</kbd> command by running <kbd> architect register</kbd> in both the front-end folder and back-end folder</li>
                                 <li>Go to the components page and deploy the app!</li>


### PR DESCRIPTION
## Overview
If using target={'_blank'} in anchor tags, react-app would throw a warning for security issue

## Changes
added `rel="noreferrer"` to <a> tags

## Pictures
N/A

## TODO List
Before merging, a PR will need
- [x] Signoff from product if there are UX changes 
- [ ] Signoff from one other engineer at Architect.io
